### PR TITLE
added github url to readme and script header

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ Author
 ------
 
 [Emil Wypych](https://emilwypych.com) [@gmail](mailto:wypychemil@gmail.com)
+[Github Repo](https://github.com/ewypych/icinga-domain-expiration-plugin)

--- a/check_domain_expiration.sh
+++ b/check_domain_expiration.sh
@@ -8,6 +8,8 @@
 #
 # Contact: wypychemil at gmail.com
 #
+# GitHub: https://github.com/ewypych/icinga-domain-expiration-plugin
+#
 #############################################
 
 # default days for warning (can change with -w cmd)


### PR DESCRIPTION
Having the github url in the script and readme makes things easier for the future (eg people finding this script on servers or even elsewhere on the internet).

see https://github.com/ewypych/icinga-domain-expiration-plugin/issues/17