### PR TITLE
Feature/add support to co tech digital and whois server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Example of use
 
 ```sh
 ./check_domain_expiration.sh -d google.com -w 60 -c 30
+or
+./check_domain_expiration.sh -d youdomain.com.au -s crazydomains.com
 ```
 
 Requirements
@@ -49,6 +51,13 @@ Supported Top-level Domains
 * im
 * uk
 * co.uk
+* tech
+* co
+* digital
+
+Supported Whois Servers
+
+* whois.crazydomains.com
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Supported Top-level Domains
 Supported Whois Servers
 
 * whois.crazydomains.com
+* whois.cloudflare.com
 
 License
 -------

--- a/check_domain_expiration.sh
+++ b/check_domain_expiration.sh
@@ -308,7 +308,7 @@ check_domain_by_whois()
 
 	if [ "$SERVER" == "whois.crazydomains.com" ]
 	then
-		EXDATE_TMP=$(${WHOIS} -h ${SERVER} "${1}" | grep -i 'Expiration Date' | ${AWK} '{ print $5 }' ) 
+		EXDATE_TMP=$(${WHOIS} -h ${SERVER} "${DOMAIN}" | grep -i 'Expiration Date' | ${AWK} '{ print $5 }' ) 
 		if [ -z "$EXDATE_TMP" ]
 		then
 			EXP_DAYS=NULL
@@ -320,7 +320,7 @@ check_domain_by_whois()
 
 	elif [ "$SERVER" == "whois.cloudflare.com" ]
 	then
-		EXDATE_TMP=$(${WHOIS} -h ${SERVER} "${1}" | grep -i 'Expiration Date' | ${AWK} '{ print $5 }' ) 
+		EXDATE_TMP=$(${WHOIS} -h ${SERVER} "${DOMAIN}" | grep -i 'Expiration Date' | ${AWK} '{ print $5 }' ) 
 		if [ -z "$EXDATE_TMP" ]
 		then
 			EXP_DAYS=NULL

--- a/check_domain_expiration.sh
+++ b/check_domain_expiration.sh
@@ -369,11 +369,11 @@ then
 	exit 3
 fi
 
-if [ -n "$SERVER" ]
+if [ "${SERVER:=auto}" == auto ]
 then
-	check_domain_by_whois "${DOMAIN}" "${SERVER}"
-else
 	check_domain "${DOMAIN}"
+else
+	check_domain_by_whois "${DOMAIN}" "${SERVER}"
 fi
 
 # exit codes based on the check_domain result

--- a/check_domain_expiration.sh
+++ b/check_domain_expiration.sh
@@ -339,7 +339,7 @@ check_domain_by_whois()
 # Help function
 help()
 {
-	echo "Usage: $0 [ -d domain_name ] [ -w ex_days ] [ -c ex_days ] [ -h ]"
+	echo "Usage: $0 [ -d domain_name ] [ -s whois_server ] [ -w ex_days ] [ -c ex_days ] [ -h ]"
 	echo
 	echo "  -d domain        : Domain to check"
 	echo "  -s whois server  : Whois server to query by"

--- a/commands/icinga2.conf
+++ b/commands/icinga2.conf
@@ -8,6 +8,13 @@ object CheckCommand "check_domain_expiration" {
 
         arguments = {
         "-d" = { value = "$domain_check$" }
+        "-s" = { value = "$domain_server$" }
         "-w" = { value = "$domain_warning$" }
         "-c" = { value = "$domain_critical$" }
 	}
+
+	vars.domain_server = "auto"
+	vars.domain_warning = 30
+	vars.domain_critical = 7
+}
+

--- a/commands/nagios.cfg
+++ b/commands/nagios.cfg
@@ -2,5 +2,5 @@
 
 define command{
 	command_name    check_domain_expiration
-	command_line    /usr/local/nagios/libexec/check_domain_expiration -d $HOSTNAME$ -w $ARG1$ -c $ARG2$
+	command_line    /usr/local/nagios/libexec/check_domain_expiration -d $HOSTNAME$ -s WHOIS_SERVER -w $ARG1$ -c $ARG2$
 	}


### PR DESCRIPTION
Hi,
I had to add support to .co, tech and .digital TLDs, and I also added the option to specify a whois server.
So far, only whois.crazydomains.com is supported (so I can query for .nz domains hosted on crazydomains.)

If you could accept this changes, that would be helpful to me, in way I wont need to customize this anymore.

Thank you,
Ronan